### PR TITLE
ci: add syncronize to lint-pr-title event

### DIFF
--- a/.github/workflows/pr-lint-title.yaml
+++ b/.github/workflows/pr-lint-title.yaml
@@ -2,7 +2,7 @@ name: lint-pr-title
 
 on:
   pull_request:
-    types: [edited, opened, reopened]
+    types: [edited, opened, reopened, synchronize]
 
 permissions:
   id-token: write


### PR DESCRIPTION
- [DEVOPS-2758]
- ensures lint-pr-title is run on new commits

[DEVOPS-2758]: https://leaflink.atlassian.net/browse/DEVOPS-2758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ